### PR TITLE
Fixed unwanted logo jump in Chromium.

### DIFF
--- a/style/logo-animation.css
+++ b/style/logo-animation.css
@@ -13,6 +13,9 @@
 }
 
 @keyframes logo-offset {
+	from {
+		transform: translate(-50%, -50%);
+	}
 	to {
 	   transform: translate(-50%, -50%) translate(0, -25vh);
 	}


### PR DESCRIPTION
Fixed the issue where on the logo-offset the logo doesn't continue with the state it has after logo-entry by setting a start state to the end state of logo-entry.